### PR TITLE
Implement nameserver parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ matches = "0.1.2"
 [lib]
 name = "dns_parser"
 path = "src/lib.rs"
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,45 +31,54 @@ impl<'a> Packet<'a> {
         }
         let mut answers = Vec::with_capacity(header.answers as usize);
         for _ in 0..header.answers {
-            let name = try!(Name::scan(&data[offset..], data));
-            offset += name.byte_len();
-            if offset + 10 > data.len() {
-                return Err(Error::UnexpectedEOF);
-            }
-            let typ = try!(Type::parse(
-                BigEndian::read_u16(&data[offset..offset+2])));
-            offset += 2;
-            let cls = try!(Class::parse(
-                BigEndian::read_u16(&data[offset..offset+2])));
-            offset += 2;
-            let mut ttl = BigEndian::read_u32(&data[offset..offset+4]);
-            if ttl > i32::MAX as u32 {
-                ttl = 0;
-            }
-            offset += 4;
-            let rdlen = BigEndian::read_u16(&data[offset..offset+2]) as usize;
-            offset += 2;
-            if offset + rdlen > data.len() {
-                return Err(Error::UnexpectedEOF);
-            }
-            let data = try!(RRData::parse(typ,
-                &data[offset..offset+rdlen], data));
-            offset += rdlen;
-            answers.push(ResourceRecord {
-                name: name,
-                cls: cls,
-                ttl: ttl,
-                data: data,
-            });
+            answers.push(try!(parse_record(data, &mut offset)));
+        }
+        let mut nameservers = Vec::with_capacity(header.nameservers as usize);
+        for _ in 0..header.nameservers {
+            nameservers.push(try!(parse_record(data, &mut offset)));
         }
         Ok(Packet {
             header: header,
             questions: questions,
             answers: answers,
-            nameservers: Vec::new(), // TODO(tailhook)
+            nameservers: nameservers,
             additional: Vec::new(), // TODO(tailhook)
         })
     }
+}
+
+// Generic function to parse answer, nameservers, and additional records.
+fn parse_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<ResourceRecord<'a>, Error> {
+    let name = try!(Name::scan(&data[*offset..], data));
+    *offset += name.byte_len();
+    if *offset + 10 > data.len() {
+        return Err(Error::UnexpectedEOF);
+    }
+    let typ = try!(Type::parse(
+        BigEndian::read_u16(&data[*offset..*offset+2])));
+    *offset += 2;
+    let cls = try!(Class::parse(
+        BigEndian::read_u16(&data[*offset..*offset+2])));
+    *offset += 2;
+    let mut ttl = BigEndian::read_u32(&data[*offset..*offset+4]);
+    if ttl > i32::MAX as u32 {
+        ttl = 0;
+    }
+    *offset += 4;
+    let rdlen = BigEndian::read_u16(&data[*offset..*offset+2]) as usize;
+    *offset += 2;
+    if *offset + rdlen > data.len() {
+        return Err(Error::UnexpectedEOF);
+    }
+    let data = try!(RRData::parse(typ,
+        &data[*offset..*offset+rdlen], data));
+    *offset += rdlen;
+    Ok(ResourceRecord {
+        name: name,
+        cls: cls,
+        ttl: ttl,
+        data: data,
+    })
 }
 
 #[cfg(test)]
@@ -146,6 +155,58 @@ mod test {
             ref x => panic!("Wrong rdata {:?}", x),
         }
     }
+
+    #[test]
+    fn parse_ns_response() {
+        let response = b"\x4a\xf0\x81\x80\x00\x01\x00\x01\x00\x01\x00\x00\
+                         \x03www\x05skype\x03com\x00\x00\x01\x00\x01\
+                         \xc0\x0c\x00\x05\x00\x01\x00\x00\x0e\x10\
+                         \x00\x1c\x07\x6c\x69\x76\x65\x63\x6d\x73\x0e\x74\
+                         \x72\x61\x66\x66\x69\x63\x6d\x61\x6e\x61\x67\x65\
+                         \x72\x03\x6e\x65\x74\x00\
+                         \xc0\x42\x00\x02\x00\x01\x00\x01\xd5\xd3\x00\x11\
+                         \x01\x67\x0c\x67\x74\x6c\x64\x2d\x73\x65\x72\x76\x65\x72\x73\
+                         \xc0\x42";
+         let packet = Packet::parse(response).unwrap();
+         assert_eq!(packet.header, Header {
+             id: 19184,
+             query: false,
+             opcode: StandardQuery,
+             authoritative: false,
+             truncated: false,
+             recursion_desired: true,
+             recursion_available: true,
+             response_code: NoError,
+             questions: 1,
+             answers: 1,
+             nameservers: 1,
+             additional: 0,
+         });
+         assert_eq!(packet.questions.len(), 1);
+         assert_eq!(packet.questions[0].qtype, QT::A);
+         assert_eq!(packet.questions[0].qclass, QC::IN);
+         assert_eq!(&packet.questions[0].qname.to_string()[..], "www.skype.com");
+         assert_eq!(packet.answers.len(), 1);
+         assert_eq!(&packet.answers[0].name.to_string()[..], "www.skype.com");
+         assert_eq!(packet.answers[0].cls, C::IN);
+         assert_eq!(packet.answers[0].ttl, 3600);
+         match packet.answers[0].data {
+             RRData::CNAME(cname) => {
+                 assert_eq!(&cname.to_string()[..], "livecms.trafficmanager.net");
+             }
+             ref x => panic!("Wrong rdata {:?}", x),
+         }
+         assert_eq!(packet.nameservers.len(), 1);
+         assert_eq!(&packet.nameservers[0].name.to_string()[..], "net");
+         assert_eq!(packet.nameservers[0].cls, C::IN);
+         assert_eq!(packet.nameservers[0].ttl, 120275);
+         match packet.nameservers[0].data {
+             RRData::NS(ns) => {
+                 assert_eq!(&ns.to_string()[..], "g.gtld-servers.net");
+             }
+             ref x => panic!("Wrong rdata {:?}", x),
+         }
+     }
 
     #[test]
     fn parse_multiple_answers() {

--- a/src/rrdata.rs
+++ b/src/rrdata.rs
@@ -9,6 +9,7 @@ use {Name, Type, Error};
 #[derive(Debug)]
 pub enum RRData<'a> {
     CNAME(Name<'a>),
+    NS(Name<'a>),
     A(Ipv4Addr),
     AAAA(Ipv6Addr),
     SRV { priority: u16, weight: u16, port: u16, target: Name<'a> },
@@ -46,6 +47,9 @@ impl<'a> RRData<'a> {
             }
             Type::CNAME => {
                 Ok(RRData::CNAME(try!(Name::scan(rdata, original))))
+            }
+            Type::NS => {
+                Ok(RRData::NS(try!(Name::scan(rdata, original))))
             }
             Type::MX => {
                 if rdata.len() < 3 {


### PR DESCRIPTION
Implement nameserver parsing. Since nameservers are in the same format as the answer records,
I factored out the code used to parse answers.
