### PR TITLE
RFC: (RFC 6891) EDNS

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,5 +39,8 @@ quick_error! {
         WrongState {
             description("parser is in the wrong state")
         }
+        AdditionalOPT {
+            description("additional OPT record found")
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod rrdata;
 mod builder;
 
 pub use enums::{Type, QueryType, Class, QueryClass, ResponseCode, Opcode};
-pub use structs::{Question, ResourceRecord, Packet, SoaRecord};
+pub use structs::{Question, ResourceRecord, OptRecord, Packet, SoaRecord};
 pub use name::{Name};
 pub use error::{Error};
 pub use header::{Header};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,7 +60,8 @@ impl<'a> Packet<'a> {
 
 fn parse_opt_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<OptRecord<'a>, Error> {
     *offset += 1;
-    let typ = try!(Type::parse( BigEndian::read_u16(&data[*offset..*offset+2])));
+    let typ = try!(Type::parse(
+        BigEndian::read_u16(&data[*offset..*offset+2])));
     // check this
     *offset += 2;
     let udp = BigEndian::read_u16(&data[*offset..*offset+2]);
@@ -76,7 +77,8 @@ fn parse_opt_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<OptRecord<
     if *offset + rdlen > data.len() {
         return Err(Error::UnexpectedEOF);
     }
-    let data = try!(RRData::parse(typ, &data[*offset..*offset+rdlen], data));
+    let data = try!(RRData::parse(typ,
+        &data[*offset..*offset+rdlen], data));
     *offset += rdlen;
 
     Ok(OptRecord {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use byteorder::{BigEndian, ByteOrder};
 use {Header, Packet, Error, Question, Name, QueryType, QueryClass};
 use {Type, Class, ResourceRecord, OptRecord, RRData};
 
+const OPT_RR_START: [u8; 3] = [0, 0, 41];
 
 impl<'a> Packet<'a> {
     pub fn parse(data: &[u8]) -> Result<Packet, Error> {
@@ -40,7 +41,7 @@ impl<'a> Packet<'a> {
         let mut additional = Vec::with_capacity(header.additional as usize);
         let mut opt = None;
         for _ in 0..header.additional {
-            if data[offset..offset+3] == [0, 0, 41] {
+            if data[offset..offset+3] == OPT_RR_START {
                 opt = parse_opt_record(data, &mut offset).ok();
             } else {
                 additional.push(try!(parse_record(data, &mut offset)));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -62,7 +62,9 @@ fn parse_opt_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<OptRecord<
     *offset += 1;
     let typ = try!(Type::parse(
         BigEndian::read_u16(&data[*offset..*offset+2])));
-    // check this
+    if typ != Type::OPT {
+        return Err(Error::InvalidType(typ as u16));
+    }
     *offset += 2;
     let udp = BigEndian::read_u16(&data[*offset..*offset+2]);
     *offset += 2;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,11 @@ impl<'a> Packet<'a> {
         let mut opt = None;
         for _ in 0..header.additional {
             if offset + 3 <= data.len() && data[offset..offset+3] == OPT_RR_START {
-                opt = Some(try!(parse_opt_record(data, &mut offset)));
+                if opt.is_none() {
+                    opt = Some(try!(parse_opt_record(data, &mut offset)));
+                } else {
+                    return Err(Error::AdditionalOPT);
+                }
             } else {
                 additional.push(try!(parse_record(data, &mut offset)));
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,7 +41,7 @@ impl<'a> Packet<'a> {
         let mut additional = Vec::with_capacity(header.additional as usize);
         let mut opt = None;
         for _ in 0..header.additional {
-            if data[offset..offset+3] == OPT_RR_START {
+            if offset + 3 <= data.len() && data[offset..offset+3] == OPT_RR_START {
                 opt = Some(try!(parse_opt_record(data, &mut offset)));
             } else {
                 additional.push(try!(parse_record(data, &mut offset)));
@@ -94,6 +94,9 @@ fn parse_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<ResourceRecord
 
 // Function to parse an RFC 6891 OPT Pseudo RR
 fn parse_opt_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<OptRecord<'a>, Error> {
+    if *offset + 11 > data.len() {
+        return Err(Error::UnexpectedEOF);
+    }
     *offset += 1;
     let typ = try!(Type::parse(
         BigEndian::read_u16(&data[*offset..*offset+2])));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -42,7 +42,7 @@ impl<'a> Packet<'a> {
         let mut opt = None;
         for _ in 0..header.additional {
             if data[offset..offset+3] == OPT_RR_START {
-                opt = parse_opt_record(data, &mut offset).ok();
+                opt = Some(try!(parse_opt_record(data, &mut offset)));
             } else {
                 additional.push(try!(parse_record(data, &mut offset)));
             }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -9,6 +9,11 @@ pub struct Packet<'a> {
     pub answers: Vec<ResourceRecord<'a>>,
     pub nameservers: Vec<ResourceRecord<'a>>,
     pub additional: Vec<ResourceRecord<'a>>,
+    /// Optional Pseudo-RR
+    /// When present it is sent as an RR in the additional section. In this RR
+    /// the `class` and `ttl` fields store max udp packet size and flags
+    /// respectively. To keep `ResourceRecord` clean we store the OPT record
+    /// here.
     pub opt: Option<OptRecord<'a>>,
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -9,6 +9,7 @@ pub struct Packet<'a> {
     pub answers: Vec<ResourceRecord<'a>>,
     pub nameservers: Vec<ResourceRecord<'a>>,
     pub additional: Vec<ResourceRecord<'a>>,
+    pub opt: Option<OptRecord<'a>>,
 }
 
 /// A parsed chunk of data in the Query section of the packet
@@ -29,6 +30,16 @@ pub struct ResourceRecord<'a> {
     pub name: Name<'a>,
     pub cls: Class,
     pub ttl: u32,
+    pub data: RRData<'a>,
+}
+
+/// RFC 6891 OPT RR
+#[derive(Debug)]
+pub struct OptRecord<'a> {
+    pub udp: u16,
+    pub extrcode: u8,
+    pub version: u8,
+    pub flags: u16,
     pub data: RRData<'a>,
 }
 


### PR DESCRIPTION
This is an initial attempt at RFC 6891 EDNS support. Not fully implemented yet.

EDNS is implemented as an OPT Pseudo-RR. This is a bit of a hack as some of the RR fields are used for other than the intended purpose. For example the 16 bit class field contains the max UDP packet size supported by the senders network stack. For this reason and the fact there is only allowed at most one OPT Pseudo-RR I have implemented the OPT data as a separate part of the DNS packet rather than in the additional records vec.

Still to do is full flag support and attribute/values. Current implementation allows packets containing a OPT RR to be parsed at least.

My version of dig sends an OPT RR by default so this makes my testing easier.

Comments welcome. 
