### PR TITLE
Prevent infinite recursion in Name::Scan

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,10 @@
 quick_error! {
     /// Error parsing DNS packet
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub enum Error {
+        BadPointer {
+            description("invalid compression pointer not pointing backwards when parsing label")
+        }
         HeaderTooShort {
             description("packet is smaller than header size")
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,10 @@
 quick_error! {
     /// Error parsing DNS packet
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug)]
     pub enum Error {
         BadPointer {
-            description("invalid compression pointer not pointing backwards when parsing label")
+            description("invalid compression pointer not pointing backwards
+                         when parsing label")
         }
         HeaderTooShort {
             description("packet is smaller than header size")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate byteorder;
+#[macro_use(_tt_as_expr_hack)]
 #[macro_use(matches)] extern crate matches;
 #[macro_use(quick_error)] extern crate quick_error;
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -11,7 +11,7 @@ use {Error};
 ///
 /// This is contains just a reference to a slice that contains the data.
 /// You may turn this into a string using `.to_string()`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Name<'a>{
     labels: &'a [u8],
     /// This is the original buffer size. The compressed names in original
@@ -21,42 +21,63 @@ pub struct Name<'a>{
 
 impl<'a> Name<'a> {
     pub fn scan(data: &'a[u8], original: &'a[u8]) -> Result<Name<'a>, Error> {
+        let mut parse_data = data;
+        let mut return_pos = None;
         let mut pos = 0;
-        loop {
-            if data.len() <= pos {
+        if parse_data.len() <= pos {
+            return Err(Error::UnexpectedEOF);
+        }
+        // By setting the largest_pos to be the original len, a side effect is that the pos
+        // variable can move forwards in the buffer once.
+        let mut largest_pos = original.len();
+        let mut byte = parse_data[pos];
+        while byte != 0 {
+            if parse_data.len() <= pos {
                 return Err(Error::UnexpectedEOF);
             }
-            let byte = data[pos];
-            if byte == 0 {
-                return Ok(Name { labels: &data[..pos+1], original: original });
-            } else if byte & 0b1100_0000 == 0b1100_0000 {
-                if data.len() < pos+2 {
+            if byte & 0b1100_0000 == 0b1100_0000 {
+                if parse_data.len() < pos+2 {
                     return Err(Error::UnexpectedEOF);
                 }
-                let off = (BigEndian::read_u16(&data[pos..pos+2])
+                let off = (BigEndian::read_u16(&parse_data[pos..pos+2])
                            & !0b1100_0000_0000_0000) as usize;
                 if off >= original.len() {
                     return Err(Error::UnexpectedEOF);
                 }
-                // Validate referred to location
-                try!(Name::scan(&original[off..], original));
-                return Ok(Name { labels: &data[..pos+2], original: original });
+                // Set the value for return_pos which is the pos in the original data buffer
+                // that should be used to return after validating the offsetted labels.
+                if let None = return_pos {
+                    return_pos = Some(pos);
+                }
+
+                // Check then set largest_pos to ensure we never go backwards in the buffer.
+                if off >= largest_pos {
+                    return Err(Error::BadPointer);
+                }
+                largest_pos = off;
+                pos = 0;
+                parse_data = &original[off..];
             } else if byte & 0b1100_0000 == 0 {
                 let end = pos + byte as usize + 1;
-                if data.len() < end {
+                if parse_data.len() < end {
                     return Err(Error::UnexpectedEOF);
                 }
-                if !data[pos+1..end].is_ascii() {
+                if !parse_data[pos+1..end].is_ascii() {
                     return Err(Error::LabelIsNotAscii);
                 }
                 pos = end;
-                if data.len() <= pos {
+                if parse_data.len() <= pos {
                     return Err(Error::UnexpectedEOF);
                 }
-                continue;
             } else {
                 return Err(Error::UnknownLabelFormat);
             }
+            byte = parse_data[pos];
+        }
+        if let Some(return_pos) = return_pos {
+            return Ok(Name { labels: &data[..return_pos+2], original: original });
+        } else {
+            return Ok(Name { labels: &data[..pos+1], original: original });
         }
     }
     pub fn byte_len(&self) -> usize {
@@ -93,5 +114,28 @@ impl<'a> fmt::Display for Name<'a> {
                 unreachable!();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use Error;
+    use Name;
+
+    #[test]
+    fn parse_badpointer_same_offset() {
+        // A buffer where an offset points to itself, a bad compression pointer.
+        let buffer_same_offset = vec![192, 2, 192, 2];
+
+        assert_eq!(Name::scan(&buffer_same_offset, &buffer_same_offset), Err(Error::BadPointer));
+    }
+
+    #[test]
+    fn parse_badpointer_forward_offset() {
+        // A buffer where the offsets points back to each other which would cause infinite recursion
+        // if never checked, a bad compression pointer.
+        let buffer_forwards_offset = vec![192, 2, 192, 4, 192, 2];
+
+        assert_eq!(Name::scan(&buffer_forwards_offset, &buffer_forwards_offset), Err(Error::BadPointer));
     }
 }


### PR DESCRIPTION
This prevents a very unlikely but possible infinite recursion in the `Scan` function of `Name`. 
A buffer that begins with `[192,0]` would cause infinite recursion to occur.

I'm not sure if that was the right Error type to use though.
