### PR TITLE
Line wrap BadPointer error message correctly

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ quick_error! {
     #[derive(Debug)]
     pub enum Error {
         BadPointer {
-            description("invalid compression pointer not pointing backwards
+            description("invalid compression pointer not pointing backwards \
                          when parsing label")
         }
         HeaderTooShort {


### PR DESCRIPTION
I didn't properly format the error message before, so it printed out in two lines. This should address that, so the error message prints out in one line.
