### PR TITLE
Update matches macro name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate byteorder;
-#[macro_use(_tt_as_expr_hack)]
+#[macro_use(_matches_tt_as_expr_hack)]
 #[macro_use(matches)] extern crate matches;
 #[macro_use(quick_error)] extern crate quick_error;
 


### PR DESCRIPTION
Matches changed the macro name causing this error to appear

`src/lib.rs:2:13: 2:29 error: imported macro not found [E0469]
src/lib.rs:2 #[macro_use(_tt_as_expr_hack)]`

https://github.com/SimonSapin/rust-std-candidates/commit/889bb070c1c10ad6c26f1a177fea901635056ac1
