### PR TITLE
Add a bunch of missing class codes

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -21,6 +21,9 @@ pub struct Packet<'a> {
 #[derive(Debug)]
 pub struct Question<'a> {
     pub qname: Name<'a>,
+    /// Whether or not we prefer unicast responses.
+    /// This is used in multicast DNS.
+    pub prefer_unicast: bool,
     pub qtype: QueryType,
     pub qclass: QueryClass,
 }
@@ -33,6 +36,10 @@ pub struct Question<'a> {
 #[derive(Debug)]
 pub struct ResourceRecord<'a> {
     pub name: Name<'a>,
+    /// Whether or not the set of resource records is fully contained in the
+    /// packet, or whether there will be more resource records in future
+    /// packets. Only used for multicast DNS.
+    pub multicast_unique: bool,
     pub cls: Class,
     pub ttl: u32,
     pub data: RRData<'a>,


### PR DESCRIPTION
Previously the class code parser only understood the four main class
codes.

This modified it so that it understands all class codes.

After this, it is possible to parse mDNS records from a ChromeCast.

There is a table of possible values listed on this page
http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml

After this is added, would you please be able to release a new version to crates.io :)