### PR TITLE
Add TXT record parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::str::Utf8Error;
+
 quick_error! {
     /// Error parsing DNS packet
     #[derive(Debug)]
@@ -39,6 +41,10 @@ quick_error! {
         }
         LabelIsNotAscii {
             description("invalid characters encountered while reading label")
+        }
+        TxtDataIsNotUTF8(error: Utf8Error) {
+            description("invalid characters encountered while reading TXT")
+            display("{:?}", error)
         }
         WrongState {
             description("parser is in the wrong state")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,6 +237,49 @@ mod test {
     }
 
     #[test]
+    fn parse_txt_response_multiple_strings() {
+        let response = b"\x06%\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00\
+                          \x08facebook\x03com\x00\x00\x10\x00\x01\
+                          \xc0\x0c\x00\x10\x00\x01\x00\x01\x51\x3d\x00\x23\
+                          \x15\x76\x3d\x73\x70\x66\x31\x20\x72\x65\x64\x69\
+                          \x72\x65\x63\x74\x3d\x5f\x73\x70\x66\x2e\
+                          \x0c\x66\x61\x63\x65\x62\x6f\x6f\x6b\x2e\x63\x6f\x6d";
+
+        let packet = Packet::parse(response).unwrap();
+        assert_eq!(packet.header, Header {
+            id: 1573,
+            query: false,
+            opcode: StandardQuery,
+            authoritative: false,
+            truncated: false,
+            recursion_desired: true,
+            recursion_available: true,
+            authenticated_data: false,
+            checking_disabled: false,
+            response_code: NoError,
+            questions: 1,
+            answers: 1,
+            nameservers: 0,
+            additional: 0,
+        });
+        assert_eq!(packet.questions.len(), 1);
+        assert_eq!(packet.questions[0].qtype, QT::TXT);
+        assert_eq!(packet.questions[0].qclass, QC::IN);
+        assert_eq!(&packet.questions[0].qname.to_string()[..], "facebook.com");
+        assert_eq!(packet.answers.len(), 1);
+        assert_eq!(&packet.answers[0].name.to_string()[..], "facebook.com");
+        assert_eq!(packet.answers[0].multicast_unique, false);
+        assert_eq!(packet.answers[0].cls, C::IN);
+        assert_eq!(packet.answers[0].ttl, 86333);
+        match packet.answers[0].data {
+            RRData::TXT(ref text) => {
+                assert_eq!(text, "v=spf1 redirect=_spf.facebook.com")
+            }
+            ref x => panic!("Wrong rdata {:?}", x),
+        }
+    }
+
+    #[test]
     fn parse_response_with_multicast_unique() {
         let response = b"\x06%\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00\
                          \x07example\x03com\x00\x00\x01\x00\x01\


### PR DESCRIPTION
Add ability to add TXT record parsing. TXT records can be used to store pretty much anything (nowadays frequently used for SPF). https://tools.ietf.org/html/rfc1035#section-3.3.14

Also, there can be multiple strings for one TXT data record, so this combines them into one string, as described here, https://tools.ietf.org/html/rfc7208#section-3.3.