### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ authors = ["paul@colomiets.name"]
 [dependencies]
 quick-error = "1.0.0"
 byteorder = "1"
-matches = "0.1.2"
 
 [dev-dependencies]
+matches = "0.1.2"
 
 [lib]
 name = "dns_parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 quick-error = "1.0.0"
-byteorder = "0.4"
+byteorder = "1"
 matches = "0.1.2"
 
 [dev-dependencies]


### PR DESCRIPTION
`byteorder` has moved on, and `matches` is only used in tests.