### PR TITLE
Make it possible to build prefer_unicast questions.

### DIFF
--- a/examples/sync_tcp_client.rs
+++ b/examples/sync_tcp_client.rs
@@ -29,7 +29,7 @@ fn main() {
 fn resolve(name: &str) -> Result<(), Box<Error>> {
     let mut conn = TcpStream::connect("127.0.0.1:53")?;
     let mut builder = Builder::new_query(1, true);
-    builder.add_question(name, QueryType::A, QueryClass::IN);
+    builder.add_question(name, false, QueryType::A, QueryClass::IN);
     let packet = builder.build().map_err(|_| "truncated packet")?;
     let psize = [((packet.len() >> 8) & 0xFF) as u8,
                  (packet.len() & 0xFF) as u8];

--- a/examples/sync_udp_client.rs
+++ b/examples/sync_udp_client.rs
@@ -29,7 +29,7 @@ fn resolve(name: &str) -> Result<(), Box<Error>> {
     let sock = UdpSocket::bind("127.0.0.1:0")?;
     sock.connect("127.0.0.1:53")?;
     let mut builder = Builder::new_query(1, true);
-    builder.add_question(name, QueryType::A, QueryClass::IN);
+    builder.add_question(name, false, QueryType::A, QueryClass::IN);
     let packet = builder.build().map_err(|_| "truncated packet")?;
     sock.send(&packet)?;
     let mut buf = vec![0u8; 4096];


### PR DESCRIPTION
This is a breaking API change so I don't know if it is acceptable. Another approach would be to introduce a new builder method, `.set_prefer_unicast`:

    let mut builder = dns::Builder::new_query(0, false);
    builder.set_prefer_unicast(true)   
    builder.add_question("foo", dns::QueryType::PTR, dns::QueryClass::IN)
    builder.set_prefer_unicast(false)
    builder.add_question("bar", dns::QueryType::PTR, dns::QueryClass::IN);

But that creates a slightly weird dependency in my opinion. I don't mind though.