### PR TITLE
Implement ToString trait for records

### DIFF
--- a/src/rdata/cname.rs
+++ b/src/rdata/cname.rs
@@ -3,6 +3,13 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+impl<'a> ToString for Record<'a> {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
 impl<'a> super::Record<'a> for Record<'a> {
 
     const TYPE: isize = 5;

--- a/src/rdata/ns.rs
+++ b/src/rdata/ns.rs
@@ -3,6 +3,13 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+impl<'a> ToString for Record<'a> {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
 impl<'a> super::Record<'a> for Record<'a> {
 
     const TYPE: isize = 2;

--- a/src/rdata/ptr.rs
+++ b/src/rdata/ptr.rs
@@ -3,6 +3,13 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+impl<'a> ToString for Record<'a> {
+    #[inline]
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
 impl<'a> super::Record<'a> for Record<'a> {
 
     const TYPE: isize = 12;


### PR DESCRIPTION
This implements the `ToString` trait for every record that contains a `Name<'a>`.