### PR TITLE
Make it suitable for editing and writing packets

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,11 +1,10 @@
 use {Error};
-use rdata::Record;
 use rdata::*;
 
 /// The TYPE value according to RFC 1035
 ///
 /// All "EXPERIMENTAL" markers here are from the RFC
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub enum Type {
     /// a host addresss
     A = a::Record::TYPE,
@@ -50,7 +49,7 @@ pub enum Type {
 /// The QTYPE value according to RFC 1035
 ///
 /// All "EXPERIMENTAL" markers here are from the RFC
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub enum QueryType {
     /// a host addresss
@@ -99,7 +98,7 @@ pub enum QueryType {
 
 
 /// The CLASS value according to RFC 1035
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub enum Class {
     /// the Internet
     IN = 1,
@@ -113,7 +112,7 @@ pub enum Class {
 }
 
 /// The QCLASS value according to RFC 1035
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub enum QueryClass {
     /// the Internet
     IN = 1,
@@ -129,7 +128,7 @@ pub enum QueryClass {
 }
 
 /// The OPCODE value according to RFC 1035
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 pub enum Opcode {
     /// Normal query
     StandardQuery,
@@ -143,7 +142,7 @@ pub enum Opcode {
 
 quick_error! {
     /// The RCODE value according to RFC 1035
-    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
     #[allow(missing_docs)] // names are from spec
     pub enum ResponseCode {
         NoError

--- a/src/header.rs
+++ b/src/header.rs
@@ -16,7 +16,7 @@ mod flag {
 }
 
 /// Represents parsed header of the packet
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Ord, PartialOrd)]
 #[allow(missing_docs)] // fields are from the spec I think
 pub struct Header {
     pub id: u16,
@@ -63,6 +63,13 @@ impl Header {
             additional: BigEndian::read_u16(&data[10..12]),
         };
         Ok(header)
+    }
+
+    /// Similar to `write`, doing the same
+    pub fn write_to<W: ::std::io::Write>(&self,mut w: W) -> ::std::io::Result<()> {
+        let mut buf = [0; 12];
+        self.write(&mut buf);
+        w.write_all(&buf)
     }
     /// Write a header to a buffer slice
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,9 @@ pub mod rdata;
 
 pub use enums::{Type, QueryType, Class, QueryClass, ResponseCode, Opcode};
 pub use structs::{Question, ResourceRecord, Packet};
-pub use name::{Name};
+pub use structs::{QuestionBuf, ResourceRecordBuf, PacketBuf};
+pub use name::{Name, write_name_to};
 pub use error::{Error};
 pub use header::{Header};
-pub use rdata::{RData};
+pub use rdata::{RData,RDataBuf};
 pub use builder::{Builder};

--- a/src/name.rs
+++ b/src/name.rs
@@ -22,6 +22,20 @@ pub struct Name<'a>{
     original: &'a [u8],
 }
 
+/// Turn name (represented as string) back into a part of a DNS packet
+/// no compression is implemented, the packet may be larger than original
+/// Each part between dots must be less than 128 bytes, lest panic.
+pub fn write_name_to<W: ::std::io::Write>(n: &str, mut w: W) -> ::std::io::Result<()> {
+    use byteorder::WriteBytesExt;
+    for l in n.split('.') {
+        assert!(l.len() < 128);
+        w.write_u8(l.len() as u8)?;
+        w.write_all(l.as_bytes())?;
+    }
+    w.write_u8(0)?;    
+    Ok(())
+}
+
 impl<'a> Name<'a> {
     /// Scan the data to get Name object
     ///

--- a/src/rdata/a.rs
+++ b/src/rdata/a.rs
@@ -3,13 +3,21 @@ use std::net::Ipv4Addr;
 use Error;
 use byteorder::{BigEndian, ByteOrder};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, Hash)]
 pub struct Record(pub Ipv4Addr);
 
-impl<'a> super::Record<'a> for Record {
+impl Record {
+    pub fn write_to<W: ::std::io::Write>(&self,mut w: W) -> ::std::io::Result<()> {
+        w.write_all(&self.0.octets())?;
+        Ok(())
+    }
+}
 
+impl super::RecordType for Record {
     const TYPE: isize = 1;
+}
 
+impl<'a> super::Record<'a> for Record {
     fn parse(rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         if rdata.len() != 4 {
             return Err(Error::WrongRdataLength);

--- a/src/rdata/aaaa.rs
+++ b/src/rdata/aaaa.rs
@@ -3,13 +3,21 @@ use std::net::Ipv6Addr;
 use Error;
 use byteorder::{BigEndian, ByteOrder};
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, Hash)]
 pub struct Record(pub Ipv6Addr);
 
-impl<'a> super::Record<'a> for Record {
+impl Record {
+    pub fn write_to<W: ::std::io::Write>(&self,mut w: W) -> ::std::io::Result<()> {
+        w.write_all(&self.0.octets())?;
+        Ok(())
+    }
+}
 
+impl super::RecordType for Record {
     const TYPE: isize = 28;
+}
 
+impl<'a> super::Record<'a> for Record {
     fn parse(rdata: &'a [u8], _record: &'a [u8]) -> super::RDataResult<'a> {
         if rdata.len() != 16 {
             return Err(Error::WrongRdataLength);

--- a/src/rdata/all.rs
+++ b/src/rdata/all.rs
@@ -1,10 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
-impl<'a> super::Record<'a> for Record {
-
+impl super::RecordType for Record {
     const TYPE: isize = 255;
+}
 
+impl<'a> super::Record<'a> for Record {
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();
     }

--- a/src/rdata/axfr.rs
+++ b/src/rdata/axfr.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 252;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 252;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/cname.rs
+++ b/src/rdata/cname.rs
@@ -3,16 +3,36 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RecordBuf(String);
+
+impl<'a> Record<'a> {
+    pub fn deep_clone(&self) -> RecordBuf {
+        RecordBuf(self.to_string())
+    }
+}
+
+impl RecordBuf {
+    pub fn write_to<W: ::std::io::Write>(&self,w: W) -> ::std::io::Result<()> {
+        super::super::write_name_to(&self.0, w)?;
+        Ok(())
+    }
+}
+
 impl<'a> ToString for Record<'a> {
     #[inline]
     fn to_string(&self) -> String {
         self.0.to_string()
     }
 }
-
+impl<'a> super::RecordType for Record<'a> {
+    const TYPE: isize = 5;
+}
+impl super::RecordType for RecordBuf {
+    const TYPE: isize = 5;
+}
 impl<'a> super::Record<'a> for Record<'a> {
 
-    const TYPE: isize = 5;
 
     fn parse(rdata: &'a [u8], original: &'a [u8]) -> super::RDataResult<'a> {
         let name = Name::scan(rdata, original)?;

--- a/src/rdata/hinfo.rs
+++ b/src/rdata/hinfo.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 13;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 13;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/maila.rs
+++ b/src/rdata/maila.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 254;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 254;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/mailb.rs
+++ b/src/rdata/mailb.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 253;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 253;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/mb.rs
+++ b/src/rdata/mb.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 7;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 7;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/mf.rs
+++ b/src/rdata/mf.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 4;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 4;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/mg.rs
+++ b/src/rdata/mg.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 8;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 8;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/minfo.rs
+++ b/src/rdata/minfo.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 14;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 14;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/mr.rs
+++ b/src/rdata/mr.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 9;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 9;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/ns.rs
+++ b/src/rdata/ns.rs
@@ -3,6 +3,22 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RecordBuf(String);
+
+impl<'a> Record<'a> {
+    pub fn deep_clone(&self) -> RecordBuf {
+        RecordBuf(self.to_string())
+    }
+}
+
+impl RecordBuf {
+    pub fn write_to<W: ::std::io::Write>(&self,w: W) -> ::std::io::Result<()> {
+        super::super::write_name_to(&self.0, w)?;
+        Ok(())
+    }
+}
+
 impl<'a> ToString for Record<'a> {
     #[inline]
     fn to_string(&self) -> String {
@@ -10,9 +26,13 @@ impl<'a> ToString for Record<'a> {
     }
 }
 
-impl<'a> super::Record<'a> for Record<'a> {
-
+impl<'a> super::RecordType for Record<'a> {
     const TYPE: isize = 2;
+}
+impl super::RecordType for RecordBuf {
+    const TYPE: isize = 2;
+}
+impl<'a> super::Record<'a> for Record<'a> {
 
     fn parse(rdata: &'a [u8], original: &'a [u8]) -> super::RDataResult<'a> {
         let name = Name::scan(rdata, original)?;

--- a/src/rdata/nsec.rs
+++ b/src/rdata/nsec.rs
@@ -1,9 +1,10 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
-impl<'a> super::Record<'a> for Record {
-
+impl super::RecordType for Record {
     const TYPE: isize = 47;
+}
+impl<'a> super::Record<'a> for Record {
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/null.rs
+++ b/src/rdata/null.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 10;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 10;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/opt.rs
+++ b/src/rdata/opt.rs
@@ -8,9 +8,41 @@ pub struct Record<'a> {
     pub data: super::RData<'a>,
 }
 
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RecordBuf {
+    pub udp: u16,
+    pub extrcode: u8,
+    pub version: u8,
+    pub flags: u16,
+    pub data: super::RDataBuf,
+}
+
+impl<'a> Record<'a> {
+    pub fn deep_clone(&self) -> RecordBuf {
+        RecordBuf{
+            udp: self.udp,
+            extrcode: self.extrcode,
+            version: self.version,
+            flags: self.flags,
+            data: self.data.deep_clone(),
+        }
+    }
+}
+
+impl RecordBuf {
+    pub fn write_to<W: ::std::io::Write>(&self,_w: W) -> ::std::io::Result<()> {
+        unimplemented!()
+    }
+}
+
+impl<'a> super::RecordType for Record<'a> {
+    const TYPE: isize = 41;
+}
+impl super::RecordType for RecordBuf {
+    const TYPE: isize = 41;
+}
 impl<'a> super::Record<'a> for Record<'a> {
 
-    const TYPE: isize = 41;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/rdata/ptr.rs
+++ b/src/rdata/ptr.rs
@@ -3,6 +3,22 @@ use Name;
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
 
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RecordBuf(String);
+
+impl RecordBuf {
+    pub fn write_to<W: ::std::io::Write>(&self,w: W) -> ::std::io::Result<()> {
+        super::super::write_name_to(&self.0, w)?;
+        Ok(())
+    }
+}
+
+impl<'a> Record<'a> {
+    pub fn deep_clone(&self) -> RecordBuf {
+        RecordBuf(self.to_string())
+    }
+}
+
 impl<'a> ToString for Record<'a> {
     #[inline]
     fn to_string(&self) -> String {
@@ -10,9 +26,14 @@ impl<'a> ToString for Record<'a> {
     }
 }
 
+impl<'a> super::RecordType for Record<'a> {
+    const TYPE: isize = 12;
+}
+impl super::RecordType for RecordBuf {
+    const TYPE: isize = 12;
+}
 impl<'a> super::Record<'a> for Record<'a> {
 
-    const TYPE: isize = 12;
 
     fn parse(rdata: &'a [u8], original: &'a [u8]) -> super::RDataResult<'a> {
         let name = Name::scan(rdata, original)?;

--- a/src/rdata/txt.rs
+++ b/src/rdata/txt.rs
@@ -4,6 +4,20 @@ use Error;
 pub struct Record<'a> {
     bytes: &'a [u8],
 }
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub struct RecordBuf(Vec<u8>);
+
+impl<'a> Record<'a> {
+    pub fn deep_clone(&self) -> RecordBuf {
+        RecordBuf(self.bytes.to_vec())
+    }
+}
+impl RecordBuf {
+    pub fn write_to<W: ::std::io::Write>(&self,mut w: W) -> ::std::io::Result<()> {
+        w.write_all(&self.0)?;
+        Ok(())
+    }
+}
 
 #[derive(Debug)]
 pub struct RecordIter<'a> {
@@ -34,9 +48,14 @@ impl<'a> Record<'a> {
     }
 }
 
+impl<'a> super::RecordType for Record<'a> {
+    const TYPE: isize = 16;
+}
+impl super::RecordType for RecordBuf {
+    const TYPE: isize = 16;
+}
 impl<'a> super::Record<'a> for Record<'a> {
 
-    const TYPE: isize = 16;
 
     fn parse(rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         // Just a quick check that record is valid

--- a/src/rdata/wks.rs
+++ b/src/rdata/wks.rs
@@ -1,9 +1,11 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Record;
 
+impl super::RecordType for Record {
+    const TYPE: isize = 11;
+}
 impl<'a> super::Record<'a> for Record {
 
-    const TYPE: isize = 11;
 
     fn parse(_rdata: &'a [u8], _original: &'a [u8]) -> super::RDataResult<'a> {
         unimplemented!();

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,4 +1,5 @@
 use {QueryType, QueryClass, Name, Class, Header, RData};
+use {RDataBuf};
 use rdata::opt;
 
 
@@ -19,6 +20,33 @@ pub struct Packet<'a> {
     pub opt: Option<opt::Record<'a>>,
 }
 
+/// Owned analogue of `Packet`
+#[derive(Debug,Hash,Ord,PartialOrd,Eq,PartialEq,Clone)]
+#[allow(missing_docs)]
+pub struct PacketBuf {
+    pub header: Header,
+    pub questions: Vec<QuestionBuf>,
+    pub answers: Vec<ResourceRecordBuf>,
+    pub nameservers: Vec<ResourceRecordBuf>,
+    pub additional: Vec<ResourceRecordBuf>,
+    pub opt: Option<opt::RecordBuf>,
+}
+
+impl<'a> Packet<'a> {
+    /// Make fully owned, editable copy
+    pub fn deep_clone(&self) -> PacketBuf {
+        PacketBuf{
+            header: self.header,
+            questions: self.questions.iter().map(|x|x.deep_clone()).collect(),
+            answers: self.answers.iter().map(|x|x.deep_clone()).collect(),
+            nameservers: self.nameservers.iter().map(|x|x.deep_clone()).collect(),
+            additional: self.additional.iter().map(|x|x.deep_clone()).collect(),
+            opt: self.opt.as_ref().map(|x|x.deep_clone()),
+        }
+    }
+}
+
+
 /// A parsed chunk of data in the Query section of the packet
 #[derive(Debug)]
 #[allow(missing_docs)]  // should be covered by spec
@@ -30,6 +58,29 @@ pub struct Question<'a> {
     pub qtype: QueryType,
     pub qclass: QueryClass,
 }
+
+/// Owned analogue of `Question`
+#[derive(Debug,Hash,Ord,PartialOrd,Eq,PartialEq,Clone)]
+#[allow(missing_docs)]
+pub struct QuestionBuf {
+    pub qname: String,
+    pub prefer_unicast: bool,
+    pub qtype: QueryType,
+    pub qclass: QueryClass,
+}
+
+impl<'a> Question<'a> {
+    /// Make fully owned, editable copy
+    pub fn deep_clone(&self) -> QuestionBuf {
+        QuestionBuf{
+            qname: self.qname.to_string(),
+            prefer_unicast: self.prefer_unicast,
+            qtype: self.qtype,
+            qclass: self.qclass,
+        }
+    }
+}
+
 
 /// A single DNS record
 ///
@@ -47,4 +98,29 @@ pub struct ResourceRecord<'a> {
     pub cls: Class,
     pub ttl: u32,
     pub data: RData<'a>,
+}
+
+/// Owned analogue of `ResourceRecord`
+#[derive(Debug,Hash,Ord,PartialOrd,Eq,PartialEq,Clone)]
+#[allow(missing_docs)]
+pub struct ResourceRecordBuf {
+    pub name: String,
+    pub multicast_unique: bool,
+    pub cls: Class,
+    pub ttl: u32,
+    pub data: RDataBuf,
+}
+
+
+impl<'a> ResourceRecord<'a> {
+    /// Make fully owned, editable copy
+    pub fn deep_clone(&self) -> ResourceRecordBuf {
+        ResourceRecordBuf{
+            name: self.name.to_string(),
+            multicast_unique: self.multicast_unique,
+            cls: self.cls,
+            ttl: self.ttl,
+            data: self.data.deep_clone(),
+        }
+    }
 }


### PR DESCRIPTION
<s>Not tested</s> Only briefly tested for one application; allocation-intensive.

Note sure if it belongs to "dns-parser" project, may probably be as a separate crate.

May help employing proptest/QuickCheck way of doing fuzz test for dns-parser.

Intended use style:

```rust
    let p : Packet;
    let mut pp : PacketBuf = p.deep_clone();
    // edit pp
    let mut buf2 = Vec::with_capacity(1024);
    let mut c = std::io::Cursor::new(&mut buf2);
    pp.write_to(c)?;
    s.send_to(&buf2, cla)?;
```

Resolves #40.