### PR TITLE
add Name::bytes() to allow viewing the contents of a Name without going through Display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["dns", "domain", "name", "parser"]
 categories = ["parser-implementations"]
 homepage = "https://github.com/tailhook/dns-parser"
 documentation = "https://docs.rs/dns-parser"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Paul Colomiets <paul@colomiets.name>"]
 
 [features]

--- a/src/name.rs
+++ b/src/name.rs
@@ -133,13 +133,13 @@ pub struct NameBytes<'a> {
     current_label: Peekable<Iter<'a, u8>>,
 }
 
-impl Iterator for NameBytes<'_> {
-    type Item = u8;
+impl<'a> Iterator for NameBytes<'a> {
+    type Item = &'a u8;
 
-    fn next(&mut self) -> Option<u8> {
+    fn next(&mut self) -> Option<&'a u8> {
         // If we're iterating over a label, yield from that iterator
         if let Some(x) = self.current_label.next() {
-            return Some(*x);
+            return Some(x);
         }
         // If we're done with the current label and the next octet is 0 or no more bytes are left,
         // we are done.
@@ -155,7 +155,7 @@ impl Iterator for NameBytes<'_> {
         if self.current_label.peek().is_none() {
             None
         } else {
-            Some(b'.')
+            Some(&b'.')
         }
     }
 }

--- a/src/rdata/cname.rs
+++ b/src/rdata/cname.rs
@@ -1,7 +1,15 @@
 use Name;
+use name::NameBytes;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Record<'a>(pub Name<'a>);
+
+impl<'a> Record<'a> {
+    #[inline]
+    pub fn bytes(&self) -> NameBytes<'_> {
+        self.0.bytes()
+    }
+}
 
 impl<'a> ToString for Record<'a> {
     #[inline]


### PR DESCRIPTION
Previously, the only way to access the contents of a `Name` was to use its `Display` impl. This incurs massive performance overhead if the new allocation and treatment as UTF-8 is not required.

This adds a method to access the contents of a domain name through an iterator which doesn't require copying anything. The iterator yields `u8` instead of `&u8` because it also inserts a `b'.'` between the labels, which does not have an owner. This could be changed to yield `&u8` instead, if we choose somewhere to stash the delimiter.