### PR TITLE
Improves way pattern is implemented for `Builder`

### DIFF
--- a/examples/sync_tcp_client.rs
+++ b/examples/sync_tcp_client.rs
@@ -28,8 +28,8 @@ fn main() {
 
 fn resolve(name: &str) -> Result<(), Box<Error>> {
     let mut conn = TcpStream::connect("127.0.0.1:53")?;
-    let mut builder = Builder::new_query(1, true);
-    builder.add_question(name, false, QueryType::A, QueryClass::IN);
+    let builder = Builder::new_query(1, true)
+        .add_question(name, false, QueryType::A, QueryClass::IN);
     let packet = builder.build().map_err(|_| "truncated packet")?;
     let psize = [((packet.len() >> 8) & 0xFF) as u8,
                  (packet.len() & 0xFF) as u8];

--- a/examples/sync_udp_client.rs
+++ b/examples/sync_udp_client.rs
@@ -5,17 +5,15 @@ use std::error::Error;
 use std::net::UdpSocket;
 use std::process;
 
-
-use dns_parser::{Builder, Packet, RData, ResponseCode};
 use dns_parser::rdata::a::Record;
-use dns_parser::{QueryType, QueryClass};
-
+use dns_parser::{Builder, Packet, RData, ResponseCode};
+use dns_parser::{QueryClass, QueryType};
 
 fn main() {
     let mut code = 0;
     for name in env::args().skip(1) {
         match resolve(&name) {
-            Ok(()) => {},
+            Ok(()) => {}
             Err(e) => {
                 eprintln!("Error resolving {:?}: {}", name, e);
                 code = 1;
@@ -28,8 +26,8 @@ fn main() {
 fn resolve(name: &str) -> Result<(), Box<Error>> {
     let sock = UdpSocket::bind("127.0.0.1:0")?;
     sock.connect("127.0.0.1:53")?;
-    let mut builder = Builder::new_query(1, true);
-    builder.add_question(name, false, QueryType::A, QueryClass::IN);
+    let builder =
+        Builder::new_query(1, true).add_question(name, false, QueryType::A, QueryClass::IN);
     let packet = builder.build().map_err(|_| "truncated packet")?;
     sock.send(&packet)?;
     let mut buf = vec![0u8; 4096];

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
-use byteorder::{ByteOrder, BigEndian, WriteBytesExt};
+use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 
-use {Opcode, ResponseCode, Header, QueryType, QueryClass};
+use {Header, Opcode, QueryClass, QueryType, ResponseCode};
 
 /// Allows to build a DNS packet
 ///
@@ -45,22 +45,27 @@ impl Builder {
     /// * Answers, nameservers or additional section has already been written
     /// * There are already 65535 questions in the buffer.
     /// * When name is invalid
-    pub fn add_question(&mut self, qname: &str, prefer_unicast: bool,
-        qtype: QueryType, qclass: QueryClass)
-        -> &mut Builder
-    {
+    pub fn add_question(
+        mut self,
+        qname: &str,
+        prefer_unicast: bool,
+        qtype: QueryType,
+        qclass: QueryClass,
+    ) -> Builder {
         if &self.buf[6..12] != b"\x00\x00\x00\x00\x00\x00" {
             panic!("Too late to add a question");
         }
         self.write_name(qname);
         self.buf.write_u16::<BigEndian>(qtype as u16).unwrap();
         let prefer_unicast: u16 = if prefer_unicast { 0x8000 } else { 0x0000 };
-        self.buf.write_u16::<BigEndian>(qclass as u16 | prefer_unicast).unwrap();
+        self.buf
+            .write_u16::<BigEndian>(qclass as u16 | prefer_unicast)
+            .unwrap();
         let oldq = BigEndian::read_u16(&self.buf[4..6]);
         if oldq == 65535 {
             panic!("Too many questions");
         }
-        BigEndian::write_u16(&mut self.buf[4..6], oldq+1);
+        BigEndian::write_u16(&mut self.buf[4..6], oldq + 1);
         self
     }
     fn write_name(&mut self, name: &str) {
@@ -86,7 +91,7 @@ impl Builder {
     /// appropriate.
     // TODO(tailhook) does the truncation make sense for TCP, and how
     // to treat it for EDNS0?
-    pub fn build(mut self) -> Result<Vec<u8>,Vec<u8>> {
+    pub fn build(mut self) -> Result<Vec<u8>, Vec<u8>> {
         // TODO(tailhook) optimize labels
         if self.buf.len() > 512 {
             Header::set_truncated(&mut self.buf[..12]);
@@ -99,14 +104,13 @@ impl Builder {
 
 #[cfg(test)]
 mod test {
-    use QueryType as QT;
-    use QueryClass as QC;
     use super::Builder;
+    use QueryClass as QC;
+    use QueryType as QT;
 
     #[test]
     fn build_query() {
-        let mut bld = Builder::new_query(1573, true);
-        bld.add_question("example.com", false, QT::A, QC::IN);
+        let bld = Builder::new_query(1573, true).add_question("example.com", false, QT::A, QC::IN);
         let result = b"\x06%\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
                       \x07example\x03com\x00\x00\x01\x00\x01";
         assert_eq!(&bld.build().unwrap()[..], &result[..]);
@@ -114,8 +118,7 @@ mod test {
 
     #[test]
     fn build_unicast_query() {
-        let mut bld = Builder::new_query(1573, true);
-        bld.add_question("example.com", true, QT::A, QC::IN);
+        let bld = Builder::new_query(1573, true).add_question("example.com", true, QT::A, QC::IN);
         let result = b"\x06%\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
                       \x07example\x03com\x00\x00\x01\x80\x01";
         assert_eq!(&bld.build().unwrap()[..], &result[..]);
@@ -123,8 +126,12 @@ mod test {
 
     #[test]
     fn build_srv_query() {
-        let mut bld = Builder::new_query(23513, true);
-        bld.add_question("_xmpp-server._tcp.gmail.com", false, QT::SRV, QC::IN);
+        let bld = Builder::new_query(23513, true).add_question(
+            "_xmpp-server._tcp.gmail.com",
+            false,
+            QT::SRV,
+            QC::IN,
+        );
         let result = b"[\xd9\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
             \x0c_xmpp-server\x04_tcp\x05gmail\x03com\x00\x00!\x00\x01";
         assert_eq!(&bld.build().unwrap()[..], &result[..]);


### PR DESCRIPTION
Currently, the `Builder` struct uses a builder pattern. It is quite disturbing that methods takes `&mut self` instead of `mut self`, allowing code to be written like that :

```rust
let packet = Builder::new_query(1573, true)
  .add_question("example.com", true, QT::A, QC::IN)
  .build();
```

Instead of : 

```rust
let mut builder = Builder::new_query(1573, true);
builder.add_question("example.com", true, QT::A, QC::IN);
let packet = builder.build();
```